### PR TITLE
Wait for db update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM debian:stretch
+FROM debian:buster
 
 MAINTAINER Christian Luginbühl <dinkel@pimprecords.com>
 
-ENV CLAMAV_VERSION 0.100
+ENV CLAMAV_VERSION 0.101.4
 
-RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb http://http.debian.net/debian/ buster main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://http.debian.net/debian/ buster-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/ buster/updates main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         clamav-daemon=${CLAMAV_VERSION}* \
         clamav-freshclam=${CLAMAV_VERSION}* \
-        libclamunrar7 \
+        libclamunrar9 \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ function terminate() {
     kill $pids 2>/dev/null
 }
 
-trap terminate CHLD
+trap terminate CHLD SIGINT SIGTERM
 wait
 
 exit $exitcode

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -m
 
-freshclam -d &
+freshclam
 clamd &
 
 pids=`jobs -p`


### PR DESCRIPTION
1. Wait for virus database update before running clamd.
2. I could not install certain packages for `stretch`, so, I updated the debian image to `buster` and updated the packages.
3. The docker image didn't close when `Ctrl-C`d. Now, after adding it to `trap`, it will terminate on `Ctrl-C`.


If you want to build it locally:
```sh
# cd into repo
docker build -t clamavd .
docker run clamavd
```

This changes is also available via `skshetry/clamavd` image, just run via:
`docker run -p 3310:3310 skshetry/clamavd`.