### PR TITLE
Use alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,15 @@
-FROM debian:buster
+FROM alpine:3.11
 
-MAINTAINER Christian Luginbühl <dinkel@pimprecords.com>
+RUN apk add --update bash clamav clamav-libunrar && \
+    rm -fr /var/cache/apk/*
 
-ENV CLAMAV_VERSION 0.101.4
-
-RUN echo "deb http://http.debian.net/debian/ buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ buster-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ buster/updates main contrib non-free" >> /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        clamav-daemon=${CLAMAV_VERSION}* \
-        clamav-freshclam=${CLAMAV_VERSION}* \
-        libclamunrar9 \
-        wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-    chown clamav:clamav /var/lib/clamav/*.cvd
-
-RUN mkdir /var/run/clamav && \
-    chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
-
-RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
+RUN mkdir /run/clamav && \
+    chown clamav:clamav /run/clamav && \
+    chmod 750 /run/clamav && \
+    freshclam && \
+    echo "Foreground true" >> /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+    echo "Foreground true" >> /etc/clamav/freshclam.conf
 
 EXPOSE 3310
 


### PR DESCRIPTION
This uses alpine as a base image. This results in 1.7X reduction in image size (1.36X if compressed) and starts significantly faster (15 seconds vs 1min15seconds on `ubuntu:buster`).
