### PR TITLE
Schedule build each month to keep image fresh

### DIFF
--- a/.github/workflows/scheduled-build-workflow.yml
+++ b/.github/workflows/scheduled-build-workflow.yml
@@ -1,0 +1,13 @@
+name: Scheduled Docker Build
+on:
+  schedule:
+    - cron:  '0 1 1 * *'
+
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+    - name: curl
+      uses: wei/curl@v1
+      with:
+        args: -X POST --silent --output /dev/null ${{ secrets.TRIGGER_DOCKERHUB_BUILD }}


### PR DESCRIPTION
Fixes #3.

The secrets has already been set ([Settings -> Secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets)) as `TRIGGER_DOCKERHUB_BUILD`. The value is a trigger url for docker hub, which when called, triggers a build from `master`. This PR schedules the build on first day of each month at 1:00 UTC by calling the trigger-url via curl.

[The trigger url can be found here](https://hub.docker.com/repository/docker/jankaritechnepal/clamavd/builds/edit).

EDIT: [The first build ran successfully](https://github.com/JankariTech/docker-clamavd/commit/2abd0b0318e0df8a03e8d4769fce4da994a44767/checks?check_suite_id=380240571).